### PR TITLE
Play audio on title click in Discover audio screen

### DIFF
--- a/lib/modules/discover/audios/audio_card.dart
+++ b/lib/modules/discover/audios/audio_card.dart
@@ -103,23 +103,26 @@ class AudioCard extends StatelessWidget {
     );
   }
 
-  Row _headerWidget() {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Text(
-          audio.title,
-          style: bold20White,
-          overflow: TextOverflow.clip,
-        ),
-        if (audio.tags.isNotEmpty)
+  GestureDetector _headerWidget() {
+    return GestureDetector(
+      onTap: onPlayTap,
+          child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
           Text(
-            audio.tags[0],
-            style: normal16White,
-          )
-        else
-          Container(),
-      ],
+            audio.title,
+            style: bold20White,
+            overflow: TextOverflow.clip,
+          ),
+          if (audio.tags.isNotEmpty)
+            Text(
+              audio.tags[0],
+              style: normal16White,
+            )
+          else
+            Container(),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
- Play audio when clicking on the title of the audio in Discover audio screen

Before
- Nothing happening when clicking on Author name of the song

![140_before](https://user-images.githubusercontent.com/58551100/83856132-bb42a100-a736-11ea-8d0b-82e39b725313.gif)

After
- Playing audio on click of author name

![140_after](https://user-images.githubusercontent.com/58551100/83856148-c1388200-a736-11ea-93bf-9d41f149829b.gif)


