### PR TITLE
Fix followers button click

### DIFF
--- a/lib/modules/profile/other_user/other_user_page.dart
+++ b/lib/modules/profile/other_user/other_user_page.dart
@@ -71,8 +71,8 @@ class _OtherUserPageState
                     stretchModes: [
                       StretchMode.fadeTitle,
                     ],
-                    title: Opacity(
-                      opacity: top > 100 ? 0 : 1,
+                    title: Visibility(
+                      visible: top < 100,
                       child: Text(
                         controller.otherUser.name,
                         style: bold20White,


### PR DESCRIPTION
- Fix followers button in Profile screen

Before
- The username is overlapping with the Followers button, which consumed the click event
![146_before](https://user-images.githubusercontent.com/58551100/83860623-1ecfcd00-a73d-11ea-99ba-13d3c980c3fd.gif)

After
- After using Visibility widget to hide the username, the Followers button is easily clickable
![146_after](https://user-images.githubusercontent.com/58551100/83860693-3ad36e80-a73d-11ea-8a7e-a0d76ae35a2c.gif)
